### PR TITLE
check for OpenCV 3.(2+)

### DIFF
--- a/moveit_calibration_plugins/handeye_calibration_target/src/handeye_target_aruco.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_target/src/handeye_target_aruco.cpp
@@ -176,7 +176,7 @@ bool HandEyeArucoTarget::detectTargetPose(cv::Mat& image)
         cv::aruco::GridBoard::create(markers_x_, markers_y_, marker_size_real_, marker_separation_real_, dictionary);
     aruco_mutex_.unlock();
     cv::Ptr<cv::aruco::DetectorParameters> params_ptr(new cv::aruco::DetectorParameters());
-#if CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION == 2
+#if CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION >= 2
     params_ptr->doCornerRefinement = true;
 #else
     params_ptr->cornerRefinementMethod = cv::aruco::CORNER_REFINE_NONE;

--- a/moveit_calibration_plugins/handeye_calibration_target/src/handeye_target_charuco.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_target/src/handeye_target_charuco.cpp
@@ -186,7 +186,7 @@ bool HandEyeCharucoTarget::detectTargetPose(cv::Mat& image)
         cv::aruco::CharucoBoard::create(squares_x_, squares_y_, square_size_meters, marker_size_meters_, dictionary);
     charuco_mutex_.unlock();
     cv::Ptr<cv::aruco::DetectorParameters> params_ptr(new cv::aruco::DetectorParameters());
-#if CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION == 2
+#if CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION >= 2
     params_ptr->doCornerRefinement = true;
 #else
     params_ptr->cornerRefinementMethod = cv::aruco::CORNER_REFINE_NONE;


### PR DESCRIPTION
When building with OpenCV 3.4, the target markers fail with this error:

    moveit_calibration/moveit_calibration_plugins/handeye_calibration_target/src/handeye_target_charuco.cpp:196:17: 
        error: ‘struct cv::aruco::DetectorParameters’ has no member named ‘cornerRefinementMethod’; did you mean 
        ‘cornerRefinementWinSize’?
     params_ptr->cornerRefinementMethod = cv::aruco::CORNER_REFINE_NONE;

This is because the correct code for OpenCV 3.4 is guarded by preprocessor checks that specifically look for 3.2. This PR just switches that check to pass for any minor version >=2. (Related to #5 .)