### PR TITLE
added required components to find_package(OpenCV)

### DIFF
--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED core aruco)
 
 catkin_package(
   INCLUDE_DIRS


### PR DESCRIPTION
We had an issue with a system that had OpenCV core version 3.4 installed, but OpenCV contrib at version 3.2, which led to confusing compilation errors since CMake would think it was building with OpenCV 3.4, but then the `aruco.hpp` that it found was incompatible.

This change should ensure that CMake verifies that the aruco module is included when it finds OpenCV.