### PR TITLE
Added support for Python 3

### DIFF
--- a/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
@@ -36,6 +36,11 @@
 
 #include <moveit/handeye_calibration_solver/handeye_solver_default.h>
 
+#if PY_MAJOR_VERSION >= 3
+  #define PyInt_AsLong                 PyLong_AsLong
+  #define PyString_FromString          PyUnicode_FromString
+#endif
+
 namespace moveit_handeye_calibration
 {
 const std::string LOGNAME = "handeye_solver_default";
@@ -79,7 +84,7 @@ bool HandEyeSolverDefault::solve(const std::vector<Eigen::Isometry3d>& effector_
   }
 
   char program_name[7] = "python";
-  Py_SetProgramName(program_name);
+  Py_SetProgramName(Py_DecodeLocale(program_name, NULL));
   static bool numpy_loaded{ false };
   if (!numpy_loaded)  // Py_Initialize() can only be called once when numpy is
                       // loaded, otherwise will segfault

--- a/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
@@ -84,9 +84,11 @@ bool HandEyeSolverDefault::solve(const std::vector<Eigen::Isometry3d>& effector_
   }
 
   char program_name[7] = "python";
-  wchar_t progname[strlen(program_name) + 1];
-  mbstowcs(progname, program_name, strlen(program_name) + 1);
-  Py_SetProgramName(progname);
+  #if PY_MAJOR_VERSION >= 3
+    Py_SetProgramName(Py_DecodeLocale(program_name, NULL));
+  #else
+    Py_SetProgramName(program_name);
+  #endif
   static bool numpy_loaded{ false };
   if (!numpy_loaded)  // Py_Initialize() can only be called once when numpy is
                       // loaded, otherwise will segfault

--- a/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
@@ -84,7 +84,9 @@ bool HandEyeSolverDefault::solve(const std::vector<Eigen::Isometry3d>& effector_
   }
 
   char program_name[7] = "python";
-  Py_SetProgramName(Py_DecodeLocale(program_name, NULL));
+  wchar_t progname[strlen(program_name) + 1];
+  mbstowcs(progname, program_name, strlen(program_name) + 1);
+  Py_SetProgramName(progname);
   static bool numpy_loaded{ false };
   if (!numpy_loaded)  // Py_Initialize() can only be called once when numpy is
                       // loaded, otherwise will segfault


### PR DESCRIPTION
Some functions (PyInt_AsLong and PyString_FromString) used in Python 2 are deprecated in Python 3. This changes are needed if you would like to build your project with Python3 support.