### PR TITLE
button for saving samples for debugging

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -170,6 +170,8 @@ private Q_SLOTS:
 
   void saveCameraPoseBtnClicked(bool clicked);
 
+  void saveSamplesBtnClicked(bool clicked);
+
   void planningGroupNameChanged(const QString& text);
 
   void saveJointStateBtnClicked(bool clicked);
@@ -200,6 +202,7 @@ private:
   QPushButton* save_joint_state_btn_;
   QPushButton* load_joint_state_btn_;
   QPushButton* save_camera_pose_btn_;
+  QPushButton* save_samples_btn_;
 
   // Manual calibration
   QPushButton* take_sample_btn_;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -693,7 +693,7 @@ void ControlTabWidget::saveSamplesBtnClicked(bool clicked)
   YAML::Emitter emitter;
   emitter << YAML::BeginSeq;
   for (size_t i=0; i<effector_wrt_world_.size(); i++) {
-    emitter << YAML::BeginMap;
+    emitter << YAML::Value << YAML::BeginMap;
     emitter << YAML::Key << "effector_wrt_world";
     emitter << YAML::Value << YAML::BeginSeq;
     for (size_t y=0; y<4; y++) {


### PR DESCRIPTION
This provides a way to save the samples for debugging the solver. #30 #28 

This commit adds a "Save Samples" button to the Calibrate tab. Clicking it opens a file chooser dialog, and going through it saves the collected samples in a yaml file.

The format is simple -- a list of row-major 4x4 transform matrices. Sample output is attached.

```yaml
- 
  effector_wrt_world:
    - 0.764688963748736
    - -0.6442974911606826
    - 0.01146872289901995
    - 0.4005766133871394
    - -0.644099015765711
    - -0.763667760969267
    - 0.04413625205914794
    - -0.05287948882914778
    - -0.01967858253347301
    - -0.04113749798221127
    - -0.9989596887008187
    - 0.4567383838863587
    - 0
    - 0
    - 0
    - 1
  object_wrt_sensor:
    - -0.181991113173958
    - 0.2090995110627794
    - -0.9608104417304987
    - 1.021420952922779
    - 0.05426406433777489
    - -0.973503588627963
    - -0.2221402725930574
    - 0.06951806243543547
    - -0.9818017731632976
    - -0.09256502503364099
    - 0.1658223380795368
    - 0.09857365365003552
    - 0
    - 0
    - 0
    - 1
- 
  effector_wrt_world:
    - 0.9898649053505572
    - 0.07859852096595821
    - 0.1182782383082214
    - 0.3359787157984038
    - 0.07664625510401313
    - -0.9968377627225979
    - 0.02097203825896006
    - 0.05943152500707911
    - 0.1195525856427335
    - -0.01169390063958857
    - -0.9927589999360205
    - 0.4827378559371502
    - 0
    - 0
    - 0
    - 1
  object_wrt_sensor:
    - -0.2401075583216645
    - 0.8223761431614696
    - -0.5157963930263489
    - 1.115832897605183
    - -0.09542477128033261
    - -0.5487618998514021
    - -0.8305146534160446
    - 0.02504434210009237
    - -0.9660447986124774
    - -0.1501930613295522
    - 0.2102368711917333
    - 0.1145420481544385
    - 0
    - 0
    - 0
    - 1
```