### PR TITLE
Add missing jsoncpp dependency

### DIFF
--- a/moveit_calibration_plugins/package.xml
+++ b/moveit_calibration_plugins/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>libjsoncpp-dev</depend>
 
   <build_depend>eigen</build_depend>
 


### PR DESCRIPTION
Missing dependency on `libjsoncpp-dev` added to `moveit_calibration_plugins/package.xml`. I ran into this while doing a fresh install in a Docker container.