### PR TITLE
fixes QFileDialogs option for Save Samples Button

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -675,7 +675,8 @@ void ControlTabWidget::saveSamplesBtnClicked(bool clicked)
   }
 
   QString file_name =
-      QFileDialog::getSaveFileName(this, tr("Save Samples"), "", tr("Target File (*.yaml);;All Files (*)"));
+      QFileDialog::getSaveFileName(this, tr("Save Samples"), "", tr("Target File (*.yaml);;All Files (*)"),
+                                   nullptr, QFileDialog::DontUseNativeDialog);
 
   if (file_name.isEmpty())
     return;


### PR DESCRIPTION
The dialog to choose a file to load or save doesn't appear while pressing Save Samples Button. This PR is extension of #24 which add DontUseNativeDialog option to QFileDialogs at the time of saving sample to file. 