### PR TITLE
Fix execute success issue

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -942,7 +942,7 @@ void ControlTabWidget::planFinished()
 void ControlTabWidget::executeFinished()
 {
   auto_execute_btn_->setEnabled(true);
-  if (planning_res_)
+  if (planning_res_ == ControlTabWidget::SUCCESS)
   {
     auto_progress_->setValue(auto_progress_->getValue() + 1);
     if (!frameNamesEmpty())


### PR DESCRIPTION
Thanks to @FrankLin9981 for finding this in #54. This change fixes the UI issue where you have to click "Execute" to move the arm and then click it again to take a sample.