### PR TITLE
add 'imgcodecs' to required OpenCV libs for 'cv::imread'

### DIFF
--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED aruco)
+find_package(OpenCV REQUIRED imgcodecs aruco)
 
 catkin_package(
   INCLUDE_DIRS


### PR DESCRIPTION
Using `colcon` as build system fails with linking errors `undefined reference to cv::imread`.

This PR adds `imgcodecs` to the required OpenCV libs to fix this issue.