### PR TITLE
fix: Remove directly link of plugin libraries

### DIFF
--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -26,8 +26,6 @@ catkin_package(
     handeye_calibration_target/include
     handeye_calibration_solver/include
   LIBRARIES
-    moveit_handeye_calibration_target
-    moveit_handeye_calibration_solver
   CATKIN_DEPENDS
     roscpp
     sensor_msgs

--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -26,6 +26,8 @@ catkin_package(
     handeye_calibration_target/include
     handeye_calibration_solver/include
   LIBRARIES
+    # No libraries are exported because directly linking to a plugin is "highly discouraged":
+    # http://wiki.ros.org/class_loader#Caution_of_Linking_Directly_Against_Plugin_Libraries
   CATKIN_DEPENDS
     roscpp
     sensor_msgs


### PR DESCRIPTION
As reported in issue #9 trying to load the calibration plugin in Rviz after building it I get the following error:
```
The class required for this panel, 'moveit_rviz_plugin/HandEyeCalibration', could not be loaded.
Error:
Failed to load library /root/underlay_ws/devel/lib/libmoveit_handeye_calibration_rviz_plugin.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library (Poco exception = libmoveit_planning_scene_monitor.so.1.0.4: cannot open shared object file: No such file or directory)
```
After some search I found [here](http://wiki.ros.org/class_loader) that: _pluginlib as of version 1.9 and class_loader HIGHLY discourage linking applications directly against libraries containing plugins. Often times users will place plugins into libraries along side code intended to directly be linked. Other times they want to be able to use classes as plugins as well as directly use them without a ClassLoader. This was fine in previous versions of pluginlib, but as version 1.9, pluginlib sits on top of class_loader for plugin loading which cannot handle this._

And this fixed the problem on my setup.