### PR TITLE
Revert "Use UNDERLAY feature of industrial_ci"

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -10,12 +10,12 @@ jobs:
     env:
       DOCKER_IMAGE: 'moveit/moveit:melodic-source'
       UPSTREAM_WORKSPACE: 'upstream.rosinstall'
+      BEFORE_INSTALL_UPSTREAM_DEPENDENCIES_EMBED: 'set +u && source /root/ws_moveit/install/setup.bash && set -u'
       AFTER_RUN_TARGET_TEST: './.ci.prepare_codecov'
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'"
       ADDITIONAL_DEBS: 'lcov'
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       BASEDIR: ${{ github.workspace }}/.work
-      UNDERLAY: /root/ws_moveit
       
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Reverts ros-planning/moveit_calibration#76. Locally, when I run `rosrun industrial_ci rerun_ci` with the `UNDERLAY` argument, it fails to find catkin when building the upstream workspace. Switching back to the old way fixes it.