### PR TITLE
Added cmake warning about OpenCV 3.2

### DIFF
--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED imgcodecs aruco)
 
-if("${OpenCV_VERSION_MAJOR}" STREQUAL "3" AND "${OpenCV_VERSION_MINOR}" STREQUAL "2")
+if(OpenCV_VERSION VERSION_EQUAL 3.2)
   message(WARNING "Your version of OpenCV (3.2) is known to have buggy ArUco pose detection! Use a ChArUco target or upgrade OpenCV")
 endif()
 

--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -21,6 +21,10 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED imgcodecs aruco)
 
+if("${OpenCV_VERSION_MAJOR}" STREQUAL "3" AND "${OpenCV_VERSION_MINOR}" STREQUAL "2")
+  message(WARNING "Your version of OpenCV (3.2) is known to have buggy ArUco pose detection! Use a ChArUco target or upgrade OpenCV")
+endif()
+
 catkin_package(
   INCLUDE_DIRS
     handeye_calibration_target/include


### PR DESCRIPTION
Added suggested warning about OpenCV 3.2:
```
Warnings   << moveit_calibration_plugins:cmake /home/john/ws_handeye/logs/moveit_calibration_plugins/build.cmake.000.log
CMake Warning at /home/john/ws_handeye/src/moveit_calibration/moveit_calibration_plugins/CMakeLists.txt:25 (message):
  Your version of OpenCV (3.2) is known to have buggy ArUco pose detection!
  Use a ChArUco target or upgrade OpenCV
```