### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 *Tools for robot arm hand-eye calibration.*
 
-This repository has been developed and tested on ROS Melodic and Noetic. It has not been tested on earlier ROS versions.
+| **Warning to Melodic users** |
+| --- |
+| OpenCV 3.2, which is the version in Ubuntu 18.04, has a buggy ArUco board pose detector. Do not expect adequate results if you are using an ArUco board with OpenCV 3.2. |
 
 MoveIt Calibration supports ArUco boards and ChArUco boards as calibration targets. Experiments have demonstrated that a
-ChArUco board gives more accurate results, so it is recommended. Moreover, OpenCV 3.2, which is the version in Ubuntu
-18.04, has a buggy ArUco board pose detector. Do not expect adequate results if you are using an ArUco board with OpenCV
-3.2.
+ChArUco board gives more accurate results, so it is recommended.
 
+This repository has been developed and tested on ROS Melodic and Noetic. It has not been tested on earlier ROS versions.
 When building `moveit_calibration` on ROS Melodic, `rviz_visual_tools` must also be built from source.
 
 This package was originally developed by Dr. Yu Yan at Intel, and was originally submitted as a PR to the core MoveIt

--- a/README.md
+++ b/README.md
@@ -2,15 +2,20 @@
 
 *Tools for robot arm hand-eye calibration.*
 
-This repository is still in experiemental status. It has been developed and tested on ROS Melodic. It has not been
-tested on earlier ROS versions.
+This repository has been developed and tested on ROS Melodic and Noetic. It has not been tested on earlier ROS versions.
 
-OpenCV 3.2, which is the version in Ubuntu 18.04, has a buggy ArUco board pose detector. It is recommended that you
-upgrade to OpenCV 3.4, or use a ChArUco board.
+MoveIt Calibration supports ArUco boards and ChArUco boards as calibration targets. Experiments have demonstrated that a
+ChArUco board gives more accurate results, so it is recommended. Moreover, OpenCV 3.2, which is the version in Ubuntu
+18.04, has a buggy ArUco board pose detector. Do not expect adequate results if you are using an ArUco board with OpenCV
+3.2.
 
-For full discussion of the ongoing effort from Yu Yan @ Intel, see this [Github
-discussion](https://github.com/ros-planning/moveit/issues/1070).
+When building `moveit_calibration` on ROS Melodic, `rviz_visual_tools` must also be built from source.
+
+This package was originally developed by Dr. Yu Yan at Intel, and was originally submitted as a PR to the core MoveIt
+repository. For background, see this [Github discussion](https://github.com/ros-planning/moveit/issues/1070).
 
 ## GitHub Actions - Continuous Integration
 
-[![Format](https://github.com/ros-planning/moveit_calibration/actions/workflows/format.yml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/format.yml?branch=master) [![BuildAndTest](https://github.com/ros-planning/moveit_calibration/actions/workflows/industrial_ci_action.yml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/industrial_ci_action.yml?branch=master) [![codecov](https://codecov.io/gh/ros-planning/moveit_calibration/branch/master/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/moveit_calibration)
+[![Format](https://github.com/ros-planning/moveit_calibration/actions/workflows/format.yaml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/format.yaml?branch=master)
+[![BuildAndTest](https://github.com/ros-planning/moveit_calibration/actions/workflows/industrial_ci_action.yaml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/industrial_ci_action.yaml?branch=master)
+[![codecov](https://codecov.io/gh/ros-planning/moveit_calibration/branch/master/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/moveit_calibration)

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ repository. For background, see this [Github discussion](https://github.com/ros-
 ## GitHub Actions - Continuous Integration
 
 [![Format](https://github.com/ros-planning/moveit_calibration/actions/workflows/format.yaml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/format.yaml?branch=master)
-[![BuildAndTest](https://github.com/ros-planning/moveit_calibration/actions/workflows/industrial_ci_action.yaml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/industrial_ci_action.yaml?branch=master)
+[![BuildAndTest](https://github.com/ros-planning/moveit_calibration/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/ros-planning/moveit_calibration/actions/workflows/ci.yaml?branch=master)
 [![codecov](https://codecov.io/gh/ros-planning/moveit_calibration/branch/master/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/moveit_calibration)


### PR DESCRIPTION
Updated README. Changes include:
 - Removed the statement that the repo is "still in experimental status"
 - Added mention of development/testing on Noetic
 - Added statement that ChArUco targets are recommended
 - Added mention that `rviz_visual_tools` must also be built from source on Melodic
 - Rephrased sentence about project's origin and link to MoveIt issue
 - Fixed CI badges