### PR TITLE
Add handeye and baldor dependencies in CMakeLists.txt

### DIFF
--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_geometry_msgs
   pluginlib
   sensor_msgs
+  handeye
+  baldor
 )
 
 find_package(Eigen3 REQUIRED)


### PR DESCRIPTION
Rviz kept complaining solver can’t return result until I was suggested to `apt install ros-noetic-handeye ros-noetic-baldor`.
The dependencies should be included in CMakeLists.txt.

https://github.com/ros-planning/moveit_calibration/pull/21
