### PR TITLE
Display more informative error message when solve() fails

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -404,7 +404,7 @@ bool ControlTabWidget::solveCameraRobotPose()
 {
   if (solver_ && !calibration_solver_->currentText().isEmpty())
   {
-    std::string error_message("Unknown error");
+    std::string error_message;
     bool res = solver_->solve(error_message, effector_wrt_world_, object_wrt_sensor_, sensor_mount_type_,
                               parseSolverName(calibration_solver_->currentText().toStdString(), '/'));
     if (res)
@@ -452,7 +452,7 @@ bool ControlTabWidget::solveCameraRobotPose()
     }
     else
     {
-      QMessageBox::warning(this, tr("Solver Failed"), tr(error_message.c_str()));
+      QMessageBox::warning(this, tr("Solver Failed"), tr((std::string("Error: ") + error_message).c_str()));
       return false;
     }
   }

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -405,8 +405,8 @@ bool ControlTabWidget::solveCameraRobotPose()
   if (solver_ && !calibration_solver_->currentText().isEmpty())
   {
     std::string error_message;
-    bool res = solver_->solve(error_message, effector_wrt_world_, object_wrt_sensor_, sensor_mount_type_,
-                              parseSolverName(calibration_solver_->currentText().toStdString(), '/'));
+    bool res = solver_->solve(effector_wrt_world_, object_wrt_sensor_, sensor_mount_type_,
+                              parseSolverName(calibration_solver_->currentText().toStdString(), '/'), &error_message);
     if (res)
     {
       camera_robot_pose_ = solver_->getCameraRobotPose();

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -404,7 +404,8 @@ bool ControlTabWidget::solveCameraRobotPose()
 {
   if (solver_ && !calibration_solver_->currentText().isEmpty())
   {
-    bool res = solver_->solve(effector_wrt_world_, object_wrt_sensor_, sensor_mount_type_,
+    std::string error_message("Unknown error");
+    bool res = solver_->solve(error_message, effector_wrt_world_, object_wrt_sensor_, sensor_mount_type_,
                               parseSolverName(calibration_solver_->currentText().toStdString(), '/'));
     if (res)
     {
@@ -451,7 +452,7 @@ bool ControlTabWidget::solveCameraRobotPose()
     }
     else
     {
-      QMessageBox::warning(this, tr("Solver Failed"), tr("Solver failed to return a calibration."));
+      QMessageBox::warning(this, tr("Solver Failed"), tr(error_message.c_str()));
       return false;
     }
   }

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
@@ -74,7 +74,7 @@ public:
    */
   virtual bool solve(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                      const std::vector<Eigen::Isometry3d>& object_wrt_sensor, SensorMountType setup = EYE_TO_HAND,
-                     const std::string& solver_name = "", std::string& error_message = "") = 0;
+                     const std::string& solver_name = "", std::string* error_message = nullptr) = 0;
 
   /**
    * @brief Get the result of the calibration, i.e. the camera pose with respect

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
@@ -63,18 +63,18 @@ public:
 
   /**
    * @brief Calculate camera-robot transform from the input pose samples.
-   * @param[out] error_message Description of error, if solver fails
    * @param effector_wrt_world End-effector pose (4X4 transform) with respect to
    * the world (or robot base).
    * @param object_wrt_sensor Object (calibration board) pose (4X4 transform)
    * with respect to the camera.
    * @param setup Camera mount type, {EYE_TO_HAND, EYE_IN_HAND}.
    * @param solver_name The algorithm used in the calculation.
+   * @param[out] error_message Description of error, if solver fails
    * @return If the calculation succeeds, return true. Otherwise, return false.
    */
-  virtual bool solve(std::string& error_message, const std::vector<Eigen::Isometry3d>& effector_wrt_world,
+  virtual bool solve(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                      const std::vector<Eigen::Isometry3d>& object_wrt_sensor, SensorMountType setup = EYE_TO_HAND,
-                     const std::string& solver_name = "") = 0;
+                     const std::string& solver_name = "", std::string& error_message = "") = 0;
 
   /**
    * @brief Get the result of the calibration, i.e. the camera pose with respect

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
@@ -63,6 +63,7 @@ public:
 
   /**
    * @brief Calculate camera-robot transform from the input pose samples.
+   * @param[out] error_message Description of error, if solver fails
    * @param effector_wrt_world End-effector pose (4X4 transform) with respect to
    * the world (or robot base).
    * @param object_wrt_sensor Object (calibration board) pose (4X4 transform)
@@ -71,7 +72,7 @@ public:
    * @param solver_name The algorithm used in the calculation.
    * @return If the calculation succeeds, return true. Otherwise, return false.
    */
-  virtual bool solve(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
+  virtual bool solve(std::string& error_message, const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                      const std::vector<Eigen::Isometry3d>& object_wrt_sensor, SensorMountType setup = EYE_TO_HAND,
                      const std::string& solver_name = "") = 0;
 

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_default.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_default.h
@@ -66,9 +66,9 @@ public:
 
   virtual const std::vector<std::string>& getSolverNames() const override;
 
-  virtual bool solve(std::string& error_message, const std::vector<Eigen::Isometry3d>& effector_wrt_world,
+  virtual bool solve(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                      const std::vector<Eigen::Isometry3d>& object_wrt_sensor, SensorMountType setup = EYE_TO_HAND,
-                     const std::string& solver_name = "TsaiLenz1989") override;
+                     const std::string& solver_name = "TsaiLenz1989", std::string* error_message = nullptr) override;
 
   virtual const Eigen::Isometry3d& getCameraRobotPose() const override;
 

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_default.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_default.h
@@ -66,7 +66,7 @@ public:
 
   virtual const std::vector<std::string>& getSolverNames() const override;
 
-  virtual bool solve(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
+  virtual bool solve(std::string& error_message, const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                      const std::vector<Eigen::Isometry3d>& object_wrt_sensor, SensorMountType setup = EYE_TO_HAND,
                      const std::string& solver_name = "TsaiLenz1989") override;
 

--- a/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
@@ -61,9 +61,9 @@ const Eigen::Isometry3d& HandEyeSolverDefault::getCameraRobotPose() const
   return camera_robot_pose_;
 }
 
-bool HandEyeSolverDefault::solve(std::string& error_message, const std::vector<Eigen::Isometry3d>& effector_wrt_world,
+bool HandEyeSolverDefault::solve(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                                  const std::vector<Eigen::Isometry3d>& object_wrt_sensor, SensorMountType setup,
-                                 const std::string& solver_name)
+                                 const std::string& solver_name, std::string& error_message)
 {
   // Check the size of the two sets of pose sample equal
   if (effector_wrt_world.size() != object_wrt_sensor.size())

--- a/moveit_calibration_plugins/handeye_calibration_solver/test/handeye_solver_test.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/test/handeye_solver_test.cpp
@@ -136,12 +136,12 @@ TEST_F(MoveItHandEyeSolverTester, SolveAXEQXB)
   {
     // Fake test for EYE_IN_HAND to check if segfault happens when loaded
     // multiple times
-    std::string error_message("");
+    std::string error_message;
     bool res =
-        solver_->solve(error_message, eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_IN_HAND, name);
+        solver_->solve(eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_IN_HAND, name, &error_message);
     ASSERT_TRUE(res);
     // Test EYE_TO_HAND from real data
-    res = solver_->solve(error_message, eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_TO_HAND, name);
+    res = solver_->solve(eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_TO_HAND, name, &error_message);
     ASSERT_TRUE(res);
     Eigen::Vector3d t(0.659, -0.249, 0.830);
     Eigen::Vector3d r(0.230, -2.540, 1.950);

--- a/moveit_calibration_plugins/handeye_calibration_solver/test/handeye_solver_test.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/test/handeye_solver_test.cpp
@@ -136,10 +136,12 @@ TEST_F(MoveItHandEyeSolverTester, SolveAXEQXB)
   {
     // Fake test for EYE_IN_HAND to check if segfault happens when loaded
     // multiple times
-    bool res = solver_->solve(eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_IN_HAND, name);
+    std::string error_message("");
+    bool res =
+        solver_->solve(error_message, eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_IN_HAND, name);
     ASSERT_TRUE(res);
     // Test EYE_TO_HAND from real data
-    res = solver_->solve(eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_TO_HAND, name);
+    res = solver_->solve(error_message, eef_wrt_world, obj_wrt_sensor, moveit_handeye_calibration::EYE_TO_HAND, name);
     ASSERT_TRUE(res);
     Eigen::Vector3d t(0.659, -0.249, 0.830);
     Eigen::Vector3d r(0.230, -2.540, 1.950);


### PR DESCRIPTION
Now `solve()` will output a helpful error message, and the GUI will display this in the dialog that pops up. Fixes #64 .
![handeye_cal_solver_error](https://user-images.githubusercontent.com/519268/118725870-be228e80-b7ed-11eb-8650-43ec6a4aa214.png)
