### PR TITLE
fix missing intrinsics on target type change

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
@@ -184,7 +184,7 @@ private:
 
   std::string optical_frame_;
 
-  sensor_msgs::CameraInfoPtr camera_info_;
+  sensor_msgs::CameraInfoConstPtr camera_info_;
 
   // **************************************************************
   // Ros components

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
@@ -151,9 +151,6 @@ TargetTabWidget::TargetTabWidget(QWidget* parent)
   // Initialize image publisher
   image_pub_ = it_.advertise("/handeye_calibration/target_detection", 1);
 
-  // Initialize camera info dada
-  camera_info_.reset(new sensor_msgs::CameraInfo());
-
   // Register custom types
   qRegisterMetaType<sensor_msgs::CameraInfo>();
   qRegisterMetaType<std::string>();
@@ -438,14 +435,7 @@ void TargetTabWidget::cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& 
       (msg->K != camera_info_->K || msg->P != camera_info_->P))
   {
     ROS_DEBUG_NAMED(LOGNAME, "Received camera info.");
-    camera_info_->header = msg->header;
-    camera_info_->height = msg->height;
-    camera_info_->width = msg->width;
-    camera_info_->distortion_model = msg->distortion_model;
-    camera_info_->D = msg->D;
-    camera_info_->K = msg->K;
-    camera_info_->R = msg->R;
-    camera_info_->P = msg->P;
+    camera_info_ = msg;
     target_->setCameraIntrinsicParams(camera_info_);
     Q_EMIT cameraInfoChanged(*camera_info_);
   }

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
@@ -434,25 +434,20 @@ void TargetTabWidget::imageCallback(const sensor_msgs::ImageConstPtr& msg)
 
 void TargetTabWidget::cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg)
 {
-  if (target_)
+  if (target_ && msg->height > 0 && msg->width > 0 && !msg->K.empty() && !msg->D.empty() &&
+      (msg->K != camera_info_->K || msg->P != camera_info_->P))
   {
-    if (msg->height > 0 && msg->width > 0 && !msg->K.empty() && !msg->D.empty())
-    {
-      if (msg->K != camera_info_->K || msg->P != camera_info_->P)
-      {
-        ROS_DEBUG("Received camera info.");
-        camera_info_->header = msg->header;
-        camera_info_->height = msg->height;
-        camera_info_->width = msg->width;
-        camera_info_->distortion_model = msg->distortion_model;
-        camera_info_->D = msg->D;
-        camera_info_->K = msg->K;
-        camera_info_->R = msg->R;
-        camera_info_->P = msg->P;
-        target_->setCameraIntrinsicParams(camera_info_);
-        Q_EMIT cameraInfoChanged(*camera_info_);
-      }
-    }
+    ROS_DEBUG_NAMED(LOGNAME, "Received camera info.");
+    camera_info_->header = msg->header;
+    camera_info_->height = msg->height;
+    camera_info_->width = msg->width;
+    camera_info_->distortion_model = msg->distortion_model;
+    camera_info_->D = msg->D;
+    camera_info_->K = msg->K;
+    camera_info_->R = msg->R;
+    camera_info_->P = msg->P;
+    target_->setCameraIntrinsicParams(camera_info_);
+    Q_EMIT cameraInfoChanged(*camera_info_);
   }
 }
 
@@ -461,6 +456,10 @@ void TargetTabWidget::targetTypeComboboxChanged(const QString& text)
   if (!text.isEmpty())
   {
     loadInputWidgetsForTargetType(text.toStdString());
+    if (target_)
+    {
+      target_->setCameraIntrinsicParams(camera_info_);
+    }
   }
 }
 

--- a/moveit_calibration_plugins/handeye_calibration_target/include/moveit/handeye_calibration_target/handeye_target_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_target/include/moveit/handeye_calibration_target/handeye_target_base.h
@@ -210,7 +210,7 @@ public:
    * @param msg Input camera info message.
    * @return True if the input camera info format is correct, false otherwise.
    */
-  virtual bool setCameraIntrinsicParams(const sensor_msgs::CameraInfoPtr& msg)
+  virtual bool setCameraIntrinsicParams(const sensor_msgs::CameraInfoConstPtr& msg)
   {
     if (!msg)
     {


### PR DESCRIPTION
Fix for a bug I just ran into. If the camera intrinsics were already received, and then you change the target type (ArUco/ChArUco), the new target wouldn't receive the correct intrinsics. The target object is created with default intrinsics (identity camera matrix and all zero distortion), and then the target tab wouldn't send its cached intrinsics to the target object, since they match the incoming CameraInfo message. This PR just sends the intrinsics after the new target object is created.

I also made some more stylistic changes to `cameraInfoCallback`.