### PR TITLE
Calculate and report reprojection error

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -198,6 +198,7 @@ private:
   // **************************************************************
 
   QTreeView* sample_tree_view_;
+  QLabel* reprojection_error_label_;
   QStandardItemModel* tree_view_model_;
 
   QComboBox* calibration_solver_;

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <tf2_eigen/tf2_eigen.h>
+#include <ros/console.h>
 
 namespace moveit_handeye_calibration
 {
@@ -82,6 +83,64 @@ public:
    * @return A 4X4 transform indicating the pose.
    */
   virtual const Eigen::Isometry3d& getCameraRobotPose() const = 0;
+
+  /**
+   * @brief Get the reprojection error for the given samples.
+   * @param effector_wrt_world End-effector pose (4X4 transform) with respect to
+   * the world (or robot base).
+   * @param object_wrt_sensor Object (calibration board) pose (4X4 transform)
+   * with respect to the camera.
+   * @param X The calibration, as a 4X4 transform.
+   * @param setup Camera mount type, {EYE_TO_HAND, EYE_IN_HAND}.
+   * @return Pair of translation and rotation reprojection error in meters and radians, or NaNs on error.
+   */
+  std::pair<double, double> getReprojectionError(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
+                                                 const std::vector<Eigen::Isometry3d>& object_wrt_sensor,
+                                                 const Eigen::Isometry3d& X, SensorMountType setup = EYE_TO_HAND)
+  {
+    auto ret = std::make_pair(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+    if (effector_wrt_world.size() != object_wrt_sensor.size())
+    {
+      ROS_ERROR_NAMED("moveit_calibration_handeye_solver",
+                      "Different number of optical and kinematic transforms when calculating reprojection error.");
+      return ret;
+    }
+
+    if (effector_wrt_world.empty())
+    {
+      return ret;
+    }
+
+    double rotation_err = 0;
+    double translation_err = 0;
+
+    const size_t num_motions = effector_wrt_world.size() - 1;
+    for (size_t i = 0; i < num_motions; ++i)
+    {
+      // Calculate both sides of AX = XB
+      Eigen::Isometry3d A;
+      if (setup == EYE_IN_HAND)
+        A = effector_wrt_world[i].inverse() * effector_wrt_world[i + 1];
+      else
+        A = effector_wrt_world[i] * effector_wrt_world[i + 1].inverse();
+      Eigen::Isometry3d B = object_wrt_sensor[i] * object_wrt_sensor[i + 1].inverse();
+
+      Eigen::Isometry3d AX = A * X;
+      Eigen::Isometry3d XB = X * B;
+
+      // Rotation error
+      double r_err = Eigen::AngleAxisd(AX.rotation().transpose() * XB.rotation()).angle();
+      rotation_err += r_err * r_err;
+
+      // Translation error
+      double t_err = ((AX.translation() - XB.translation()).norm() +
+                      (AX.inverse().translation() - XB.inverse().translation()).norm()) /
+                     2.;
+      translation_err += t_err * t_err;
+    }
+    ret = std::make_pair(std::sqrt(rotation_err / num_motions), std::sqrt(translation_err / num_motions));
+    return ret;
+  }
 };
 
 }  // namespace moveit_handeye_calibration

--- a/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
+++ b/moveit_calibration_plugins/handeye_calibration_solver/src/handeye_solver_default.cpp
@@ -146,7 +146,7 @@ bool HandEyeSolverDefault::solve(const std::vector<Eigen::Isometry3d>& effector_
     python_value = PyString_FromString("Moving");
   if (!python_value)
   {
-    *error_message = "Can't creat sensor mount type python value";
+    *error_message = "Can't create sensor mount type python value";
     ROS_ERROR_STREAM_NAMED(LOGNAME, *error_message);
     Py_DECREF(python_class);
     PyErr_Print();


### PR DESCRIPTION
This adds a function to the solver plugin to calculate the reprojection error. It also displays the error in the calibration tab, beneath the samples.

![reproj_err](https://user-images.githubusercontent.com/519268/120894799-8ed69480-c5d7-11eb-9149-5deac2de7062.png)
