### PR TITLE
Source build of MoveIt is unneeded

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ jobs:
             CATKIN_LINT: true
     env:
       DOCKER_IMAGE: 'moveit/moveit:${{ matrix.env.IMAGE }}-release'
-      UNDERLAY: /root/ws_moveit/install
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'RelWithDebInfo' || 'Release'}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
           - IMAGE: melodic
             CCOV: true
             CATKIN_LINT: true
-            UPSTREAM_WORKSPACE: 'melodic_upstream.rosinstall'
+            UPSTREAM_WORKSPACE: github:PickNikRobotics/rviz_visual_tools#master
           - IMAGE: noetic
             CATKIN_LINT: true
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           - IMAGE: noetic
             CATKIN_LINT: true
     env:
-      DOCKER_IMAGE: 'moveit/moveit:${{ matrix.env.IMAGE }}-source'
+      DOCKER_IMAGE: 'moveit/moveit:${{ matrix.env.IMAGE }}-release'
       UNDERLAY: /root/ws_moveit/install
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
           - IMAGE: melodic
             CCOV: true
             CATKIN_LINT: true
-            UPSTREAM_WORKSPACE: 'upstream.rosinstall'
+            UPSTREAM_WORKSPACE: 'melodic_upstream.rosinstall'
           - IMAGE: noetic
             CATKIN_LINT: true
     env:

--- a/melodic_upstream.rosinstall
+++ b/melodic_upstream.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: rviz_visual_tools
+    uri: https://github.com/PickNikRobotics/rviz_visual_tools
+    version: master

--- a/melodic_upstream.rosinstall
+++ b/melodic_upstream.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rviz_visual_tools
-    uri: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: master

--- a/upstream.rosinstall
+++ b/upstream.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rviz_visual_tools
-    uri: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: master


### PR DESCRIPTION
Source build of MoveIt (and rviz_visual_tools) is not necessary on Noetic (fixes #71).

~~This change will break the Melodic build, so maybe it's time to have separate devel branches. What would be the preferred approach at this point?~~ Actually, it works for both. I just had to learn a bit more about industrial_ci.