### PR TITLE
Convert panel to rviz display

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/CMakeLists.txt
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(OpenCV REQUIRED)
 
 set(HEADERS
-  include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h
+  include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+  include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
   include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
   include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
   include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -12,7 +13,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Plugin Source
 set(SOURCE_FILES
-  src/handeye_calibration_gui.cpp
+  src/handeye_calibration_display.cpp
+  src/handeye_calibration_frame.cpp
   src/handeye_target_widget.cpp
   src/handeye_context_widget.cpp
   src/handeye_control_widget.cpp

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -68,6 +68,12 @@ public:
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
+  rviz::StringProperty* move_group_ns_property_;
+  rviz::RosTopicProperty* planning_scene_topic_property_;
+  rviz::BoolProperty* fov_marker_enabled_property_;
+  rviz::FloatProperty* fov_marker_alpha_property_;
+  rviz::FloatProperty* fov_marker_size_property_;
+
 private Q_SLOTS:
 
   // ******************************************************************************************
@@ -81,11 +87,6 @@ private Q_SLOTS:
 
 protected:
   void onInitialize() override;
-  rviz::StringProperty* move_group_ns_property_;
-  rviz::RosTopicProperty* planning_scene_topic_property_;
-  rviz::BoolProperty* fov_marker_enabled_property_;
-  rviz::FloatProperty* fov_marker_alpha_property_;
-  rviz::FloatProperty* fov_marker_size_property_;
 
 private:
   rviz::PanelDockWidget* frame_dock_;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -47,6 +47,7 @@
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
 #include <rviz/display.h>
+#include <rviz/panel_dock_widget.h>
 #include <rviz/properties/property.h>
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/ros_topic_property.h>

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -58,17 +58,18 @@ public:
   explicit HandEyeCalibrationDisplay(QWidget* parent = 0);
   ~HandEyeCalibrationDisplay() override;
 
-  virtual void load(const rviz::Config& config) override;
-  virtual void save(rviz::Config config) const override;
+  void load(const rviz::Config& config) override;
+  void save(rviz::Config config) const override;
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
+protected:
+  void onInitialize() override;
+
 private:
+  rviz::PanelDockWidget* frame_dock_;
   HandEyeCalibrationFrame* frame_;
-  // ******************************************************************************************
-  // Ros Components
-  // ******************************************************************************************
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -36,7 +36,6 @@
 
 #pragma once
 
-// qt
 
 // ros
 #include <rviz_visual_tools/tf_visual_tools.h>

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -34,8 +34,7 @@
 
 /* Author: Yu Yan */
 
-#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
-#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
+#pragma once
 
 // qt
 
@@ -44,13 +43,10 @@
 
 // local
 #include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h>
-#include <moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h>
-#include <moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h>
-#include <moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h>
 
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
-#include <rviz/panel.h>
+#include <rviz/display.h>
 #endif
 
 namespace moveit_rviz_plugin
@@ -73,10 +69,6 @@ private:
   // ******************************************************************************************
   // Ros Components
   // ******************************************************************************************
-
-  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
 };
 
 }  // namespace moveit_rviz_plugin
-
-#endif

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -47,6 +47,10 @@
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
 #include <rviz/display.h>
+#include <rviz/properties/property.h>
+#include <rviz/properties/float_property.h>
+#include <rviz/properties/ros_topic_property.h>
+#include <rviz/properties/string_property.h>
 #endif
 
 namespace moveit_rviz_plugin
@@ -64,8 +68,24 @@ public:
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
+private Q_SLOTS:
+
+  // ******************************************************************************************
+  // Slot Event Functions
+  // ******************************************************************************************
+  void changedMoveGroupNS();
+  void changedPlanningSceneTopic();
+  void changedFOVEnabled();
+  void changedFOVAlpha();
+  void changedFOVSize();
+
 protected:
   void onInitialize() override;
+  rviz::StringProperty* move_group_ns_property_;
+  rviz::RosTopicProperty* planning_scene_topic_property_;
+  rviz::BoolProperty* fov_marker_enabled_property_;
+  rviz::FloatProperty* fov_marker_alpha_property_;
+  rviz::FloatProperty* fov_marker_size_property_;
 
 private:
   rviz::PanelDockWidget* frame_dock_;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -36,7 +36,6 @@
 
 #pragma once
 
-
 // ros
 #include <rviz_visual_tools/tf_visual_tools.h>
 
@@ -65,9 +64,6 @@ public:
   void load(const rviz::Config& config) override;
   void save(rviz::Config config) const override;
 
-  void update(float wall_dt, float ros_dt) override;
-  void reset() override;
-
   rviz::StringProperty* move_group_ns_property_;
   rviz::RosTopicProperty* planning_scene_topic_property_;
   rviz::BoolProperty* fov_marker_enabled_property_;
@@ -79,11 +75,8 @@ private Q_SLOTS:
   // ******************************************************************************************
   // Slot Event Functions
   // ******************************************************************************************
-  void changedMoveGroupNS();
-  void changedPlanningSceneTopic();
-  void changedFOVEnabled();
-  void changedFOVAlpha();
-  void changedFOVSize();
+  void fillPlanningGroupNameComboBox();
+  void updateMarkers();
 
 protected:
   void onInitialize() override;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h
@@ -1,0 +1,82 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
+#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
+
+// qt
+
+// ros
+#include <rviz_visual_tools/tf_visual_tools.h>
+
+// local
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h>
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#endif
+
+namespace moveit_rviz_plugin
+{
+class HandEyeCalibrationDisplay : public rviz::Display
+{
+  Q_OBJECT
+public:
+  explicit HandEyeCalibrationDisplay(QWidget* parent = 0);
+  ~HandEyeCalibrationDisplay() override;
+
+  virtual void load(const rviz::Config& config) override;
+  virtual void save(rviz::Config config) const override;
+
+  void update(float wall_dt, float ros_dt) override;
+  void reset() override;
+
+private:
+  HandEyeCalibrationFrame* frame_;
+  // ******************************************************************************************
+  // Ros Components
+  // ******************************************************************************************
+
+  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
+};
+
+}  // namespace moveit_rviz_plugin
+
+#endif

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
@@ -73,10 +73,7 @@ public:
   virtual void loadWidget(const rviz::Config& config);
   virtual void saveWidget(rviz::Config config) const;
 
-private:
-  rviz::DisplayContext* context_;
-  HandEyeCalibrationDisplay* calibration_display_;
-
+protected:
   // ******************************************************************************************
   // Qt Components
   // ******************************************************************************************
@@ -84,6 +81,10 @@ private:
   TargetTabWidget* tab_target_;
   ContextTabWidget* tab_context_;
   ControlTabWidget* tab_control_;
+
+private:
+  rviz::DisplayContext* context_;
+  HandEyeCalibrationDisplay* calibration_display_;
 
   rviz_visual_tools::TFVisualToolsPtr tf_tools_;
 };

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
@@ -34,8 +34,7 @@
 
 /* Author: Yu Yan */
 
-#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
-#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
+#pragma once
 
 // qt
 
@@ -43,6 +42,7 @@
 #include <rviz_visual_tools/tf_visual_tools.h>
 
 // local
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
 #include <moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h>
 #include <moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h>
 #include <moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h>
@@ -54,6 +54,8 @@
 
 namespace moveit_rviz_plugin
 {
+class HandEyeCalibrationDisplay;
+
 class HandEyeCalibrationFrame : public QWidget
 {
   friend class HandEyeCalibrationDisplay;
@@ -63,8 +65,8 @@ public:
   explicit HandEyeCalibrationFrame(QWidget* parent = 0);
   ~HandEyeCalibrationFrame() override;
 
-  virtual void load(const rviz::Config& config) override;
-  virtual void save(rviz::Config config) const override;
+  virtual void loadWidget(const rviz::Config& config);
+  virtual void saveWidget(rviz::Config config) const;
 
 private:
   // ******************************************************************************************
@@ -74,8 +76,8 @@ private:
   TargetTabWidget* tab_target_;
   ContextTabWidget* tab_context_;
   ControlTabWidget* tab_control_;
+
+  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
 };
 
 }  // namespace moveit_rviz_plugin
-
-#endif

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
@@ -56,6 +56,9 @@
 namespace moveit_rviz_plugin
 {
 class HandEyeCalibrationDisplay;
+class TargetTabWidget;
+class ContextTabWidget;
+class ControlTabWidget;
 
 class HandEyeCalibrationFrame : public QWidget
 {
@@ -63,7 +66,8 @@ class HandEyeCalibrationFrame : public QWidget
   Q_OBJECT
 
 public:
-  explicit HandEyeCalibrationFrame(rviz::DisplayContext* context, QWidget* parent = 0);
+  explicit HandEyeCalibrationFrame(HandEyeCalibrationDisplay* pdisplay, rviz::DisplayContext* context,
+                                   QWidget* parent = 0);
   ~HandEyeCalibrationFrame() override;
 
   virtual void loadWidget(const rviz::Config& config);
@@ -71,6 +75,7 @@ public:
 
 private:
   rviz::DisplayContext* context_;
+  HandEyeCalibrationDisplay* calibration_display_;
 
   // ******************************************************************************************
   // Qt Components

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
@@ -54,15 +54,17 @@
 
 namespace moveit_rviz_plugin
 {
-class HandEyeCalibrationGui : public rviz::Panel
+class HandEyeCalibrationFrame : public QWidget
 {
+  friend class HandEyeCalibrationDisplay;
   Q_OBJECT
-public:
-  explicit HandEyeCalibrationGui(QWidget* parent = 0);
-  ~HandEyeCalibrationGui() override;
 
-  virtual void load(const rviz::Config& config);
-  virtual void save(rviz::Config config) const;
+public:
+  explicit HandEyeCalibrationFrame(QWidget* parent = 0);
+  ~HandEyeCalibrationFrame() override;
+
+  virtual void load(const rviz::Config& config) override;
+  virtual void save(rviz::Config config) const override;
 
 private:
   // ******************************************************************************************
@@ -72,12 +74,6 @@ private:
   TargetTabWidget* tab_target_;
   ContextTabWidget* tab_context_;
   ControlTabWidget* tab_control_;
-
-  // ******************************************************************************************
-  // Ros Components
-  // ******************************************************************************************
-
-  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h
@@ -49,7 +49,8 @@
 
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
-#include <rviz/panel.h>
+#include <rviz/display_factory.h>
+#include <rviz/display_context.h>
 #endif
 
 namespace moveit_rviz_plugin
@@ -62,13 +63,15 @@ class HandEyeCalibrationFrame : public QWidget
   Q_OBJECT
 
 public:
-  explicit HandEyeCalibrationFrame(QWidget* parent = 0);
+  explicit HandEyeCalibrationFrame(rviz::DisplayContext* context, QWidget* parent = 0);
   ~HandEyeCalibrationFrame() override;
 
   virtual void loadWidget(const rviz::Config& config);
   virtual void saveWidget(rviz::Config config) const;
 
 private:
+  rviz::DisplayContext* context_;
+
   // ******************************************************************************************
   // Qt Components
   // ******************************************************************************************

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
@@ -196,9 +196,6 @@ private Q_SLOTS:
   // Called when the slider of initial camera pose guess changed
   void updateCameraMarkerPose(double value);
 
-  // Called when the fov_on_off_ button toggled
-  void fovOnOffBtnToggled(bool checked);
-
 Q_SIGNALS:
 
   void sensorMountTypeChanged(int index);
@@ -217,10 +214,6 @@ private:
 
   // Frame selection area
   std::map<std::string, TFFrameNameComboBox*> frames_;
-
-  // FOV setting area
-  QRadioButton* fov_on_off_;
-  SliderWidget* fov_alpha_;
 
   // Initial camera pose
   std::map<std::string, SliderWidget*> guess_pose_;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
@@ -34,8 +34,7 @@
 
 /* Author: Yu Yan */
 
-#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CONTEXT_WIDGET_
-#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CONTEXT_WIDGET_
+#pragma once
 
 // qt
 #include <QLabel>
@@ -59,6 +58,7 @@
 #include <image_geometry/pinhole_camera_model.h>
 #include <moveit_visual_tools/moveit_visual_tools.h>
 #include <moveit/handeye_calibration_solver/handeye_solver_base.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
 
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
@@ -70,6 +70,8 @@ namespace mhc = moveit_handeye_calibration;
 
 namespace moveit_rviz_plugin
 {
+class HandEyeCalibrationDisplay;
+
 enum FRAME_SOURCE
 {
   ROBOT_FRAME = 0,
@@ -149,7 +151,7 @@ class ContextTabWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit ContextTabWidget(QWidget* parent = Q_NULLPTR);
+  explicit ContextTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* parent = Q_NULLPTR);
   ~ContextTabWidget()
   {
     camera_info_.reset();
@@ -204,6 +206,8 @@ Q_SIGNALS:
   void frameNameChanged(std::map<std::string, std::string> names);
 
 private:
+  HandEyeCalibrationDisplay* calibration_display_;
+
   // **************************************************************
   // Qt components
   // **************************************************************
@@ -246,5 +250,3 @@ private:
 };
 
 }  // namespace moveit_rviz_plugin
-
-#endif

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -153,6 +153,8 @@ public:
 
   void computeExecution();
 
+  void fillPlanningGroupNameComboBox();
+
 Q_SIGNALS:
 
   void sensorPoseUpdate(double x, double y, double z, double rx, double ry, double rz);
@@ -182,8 +184,6 @@ private Q_SLOTS:
   void setGroupName(const std::string& group_name);
 
   void planningGroupNamespaceChanged();
-
-  void fillPlanningGroupNameComboBox();
 
   void saveJointStateBtnClicked(bool clicked);
 

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -179,6 +179,12 @@ private Q_SLOTS:
 
   void planningGroupNameChanged(const QString& text);
 
+  void setGroupName(const std::string& group_name);
+
+  void planningGroupNamespaceChanged();
+
+  void fillPlanningGroupNameComboBox();
+
   void saveJointStateBtnClicked(bool clicked);
 
   void loadJointStateBtnClicked(bool clicked);

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -34,8 +34,7 @@
 
 /* Author: Yu Yan */
 
-#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATE_WIDGET_
-#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATE_WIDGET_
+#pragma once
 
 // qt
 #include <QFile>
@@ -64,7 +63,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/handeye_calibration_solver/handeye_solver_base.h>
 #include <moveit/background_processing/background_processing.h>
-#include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
 
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
@@ -77,6 +76,8 @@ namespace mhc = moveit_handeye_calibration;
 
 namespace moveit_rviz_plugin
 {
+class HandEyeCalibrationDisplay;
+
 class ProgressBarWidget : public QWidget
 {
   Q_OBJECT
@@ -113,7 +114,7 @@ class ControlTabWidget : public QWidget
   };
 
 public:
-  explicit ControlTabWidget(QWidget* parent = Q_NULLPTR);
+  explicit ControlTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* parent = Q_NULLPTR);
   ~ControlTabWidget()
   {
     tf_tools_.reset();
@@ -193,6 +194,8 @@ private Q_SLOTS:
   void executeFinished();
 
 private:
+  HandEyeCalibrationDisplay* calibration_display_;
+
   // **************************************************************
   // Qt components
   // **************************************************************
@@ -261,4 +264,3 @@ private:
 };
 
 }  // namespace moveit_rviz_plugin
-#endif

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
@@ -34,8 +34,7 @@
 
 /* Author: Yu Yan */
 
-#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_TARGET_WIDGET_
-#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_TARGET_WIDGET_
+#pragma once
 
 // qt
 #include <QSet>
@@ -68,6 +67,7 @@
 #include <pluginlib/class_loader.hpp>
 #include <rviz_visual_tools/tf_visual_tools.h>
 #include <moveit/handeye_calibration_target/handeye_target_base.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
 
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
@@ -79,6 +79,8 @@ Q_DECLARE_METATYPE(std::string);
 
 namespace moveit_rviz_plugin
 {
+class HandEyeCalibrationDisplay;
+
 // **************************************************
 // Custom QComboBox for image and camera_info topic
 // **************************************************
@@ -108,7 +110,7 @@ class TargetTabWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit TargetTabWidget(QWidget* parent = Q_NULLPTR);
+  explicit TargetTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* parent = Q_NULLPTR);
   ~TargetTabWidget()
   {
     target_.reset();
@@ -156,6 +158,8 @@ Q_SIGNALS:
   void opticalFrameChanged(const std::string& frame_id);
 
 private:
+  HandEyeCalibrationDisplay* calibration_display_;
+
   // **************************************************************
   // Qt components
   // **************************************************************
@@ -201,5 +205,3 @@ private:
 };
 
 }  // namespace moveit_rviz_plugin
-
-#endif

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -48,6 +48,24 @@ namespace moveit_rviz_plugin
 {
 HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display()
 {
+  move_group_ns_property_ = new rviz::StringProperty("Move Group Namespace", "",
+                                                     "The name of the ROS namespace in "
+                                                     "which the move_group node is running",
+                                                     this, SLOT(changedMoveGroupNS()), this);
+  planning_scene_topic_property_ =
+      new rviz::RosTopicProperty("Planning Scene Topic", "move_group/monitored_planning_scene",
+                                 ros::message_traits::datatype<moveit_msgs::PlanningScene>(),
+                                 "The topic on which the moveit_msgs::PlanningScene messages are received", this,
+                                 SLOT(changedPlanningSceneTopic()), this);
+
+  fov_marker_enabled_property_ = new rviz::BoolProperty(
+      "Camera FOV Marker", true, "Enable marker showing camera field of view", this, SLOT(changedFOVEnabled()), this);
+  fov_marker_alpha_property_ =
+      new rviz::FloatProperty("Marker Alpha", 0.3f, "Specifies the alpha (transparency) for the rendered marker",
+                              fov_marker_enabled_property_, SLOT(changedFOVAlpha()), this);
+  fov_marker_size_property_ =
+      new rviz::FloatProperty("Marker Size", 1.f, "Specifies the size (depth in meters) for the rendered marker",
+                              fov_marker_enabled_property_, SLOT(changedFOVSize()), this);
 }
 
 void HandEyeCalibrationDisplay::onInitialize()
@@ -61,28 +79,79 @@ void HandEyeCalibrationDisplay::onInitialize()
   {
     frame_dock_ = window_context->addPane("HandEye Calibration", frame_);
   }
+  setStatus(rviz::StatusProperty::Ok, "Hello", "world");
 }
 
 HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay() = default;
 
 void HandEyeCalibrationDisplay::save(rviz::Config config) const
 {
-  frame_->saveWidget(config);
+  Display::save(config);
+  if (frame_)
+  {
+    frame_->saveWidget(config);
+  }
 }
 
 // Load all configuration data for this panel from the given Config object.
 void HandEyeCalibrationDisplay::load(const rviz::Config& config)
 {
-  frame_->loadWidget(config);
-
-  ROS_INFO_STREAM("handeye calibration gui loaded.");
+  Display::load(config);
+  if (frame_)
+  {
+    frame_->loadWidget(config);
+  }
 }
 
 void HandEyeCalibrationDisplay::update(float wall_dt, float ros_dt)
 {
+  Display::update(wall_dt, ros_dt);
 }
 
 void HandEyeCalibrationDisplay::reset()
 {
+  Display::reset();
 }
+
+void HandEyeCalibrationDisplay::changedMoveGroupNS()
+{
+  // TODO
+}
+
+void HandEyeCalibrationDisplay::changedPlanningSceneTopic()
+{
+  // TODO
+  /*
+  if (planning_scene_monitor_ && planning_scene_topic_property_)
+  {
+    planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
+    std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
+    if (!getMoveGroupNS().empty())
+      service_name = ros::names::append(getMoveGroupNS(), service_name);
+    auto bg_func = [=]() {
+      if (planning_scene_monitor_->requestPlanningSceneState(service_name))
+        addMainLoopJob(boost::bind(&PlanningSceneDisplay::onNewPlanningSceneState, this));
+      else
+        setStatus(rviz::StatusProperty::Warn, "PlanningScene", "Requesting initial scene failed");
+    };
+    addBackgroundJob(bg_func, "requestPlanningSceneState");
+  }
+  */
+}
+
+void HandEyeCalibrationDisplay::changedFOVEnabled()
+{
+  // TODO
+}
+
+void HandEyeCalibrationDisplay::changedFOVAlpha()
+{
+  // TODO
+}
+
+void HandEyeCalibrationDisplay::changedFOVSize()
+{
+  // TODO
+}
+
 }  // namespace moveit_rviz_plugin

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -51,21 +51,21 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
   move_group_ns_property_ = new rviz::StringProperty("Move Group Namespace", "",
                                                      "The name of the ROS namespace in "
                                                      "which the move_group node is running",
-                                                     this, SLOT(changedMoveGroupNS()), this);
+                                                     this, SLOT(fillPlanningGroupNameComboBox()), this);
   planning_scene_topic_property_ =
       new rviz::RosTopicProperty("Planning Scene Topic", "move_group/monitored_planning_scene",
                                  ros::message_traits::datatype<moveit_msgs::PlanningScene>(),
                                  "The topic on which the moveit_msgs::PlanningScene messages are received", this,
-                                 SLOT(changedPlanningSceneTopic()), this);
+                                 SLOT(fillPlanningGroupNameComboBox()), this);
 
   fov_marker_enabled_property_ = new rviz::BoolProperty(
-      "Camera FOV Marker", true, "Enable marker showing camera field of view", this, SLOT(changedFOVEnabled()), this);
+      "Camera FOV Marker", true, "Enable marker showing camera field of view", this, SLOT(updateMarkers()), this);
   fov_marker_alpha_property_ =
       new rviz::FloatProperty("Marker Alpha", 0.3f, "Specifies the alpha (transparency) for the rendered marker",
-                              fov_marker_enabled_property_, SLOT(changedFOVAlpha()), this);
+                              fov_marker_enabled_property_, SLOT(updateMarkers()), this);
   fov_marker_size_property_ =
       new rviz::FloatProperty("Marker Size", 1.5f, "Specifies the size (depth in meters) for the rendered marker",
-                              fov_marker_enabled_property_, SLOT(changedFOVSize()), this);
+                              fov_marker_enabled_property_, SLOT(updateMarkers()), this);
 }
 
 HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay()
@@ -106,17 +106,7 @@ void HandEyeCalibrationDisplay::load(const rviz::Config& config)
   }
 }
 
-void HandEyeCalibrationDisplay::update(float wall_dt, float ros_dt)
-{
-  Display::update(wall_dt, ros_dt);
-}
-
-void HandEyeCalibrationDisplay::reset()
-{
-  Display::reset();
-}
-
-void HandEyeCalibrationDisplay::changedMoveGroupNS()
+void HandEyeCalibrationDisplay::fillPlanningGroupNameComboBox()
 {
   if (frame_ && frame_->tab_control_)
   {
@@ -124,31 +114,7 @@ void HandEyeCalibrationDisplay::changedMoveGroupNS()
   }
 }
 
-void HandEyeCalibrationDisplay::changedPlanningSceneTopic()
-{
-  if (frame_ && frame_->tab_control_)
-  {
-    frame_->tab_control_->fillPlanningGroupNameComboBox();
-  }
-}
-
-void HandEyeCalibrationDisplay::changedFOVEnabled()
-{
-  if (frame_ && frame_->tab_context_)
-  {
-    frame_->tab_context_->updateAllMarkers();
-  }
-}
-
-void HandEyeCalibrationDisplay::changedFOVAlpha()
-{
-  if (frame_ && frame_->tab_context_)
-  {
-    frame_->tab_context_->updateAllMarkers();
-  }
-}
-
-void HandEyeCalibrationDisplay::changedFOVSize()
+void HandEyeCalibrationDisplay::updateMarkers()
 {
   if (frame_ && frame_->tab_context_)
   {

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -44,7 +44,7 @@ namespace moveit_rviz_plugin
 {
 HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : rviz::Display()
 {
-  frame_ = new HandEyeCalibrationFrame::HandEyeCalibrationFrame();
+  frame_ = new HandEyeCalibrationFrame();
 }
 
 HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay() = default;
@@ -57,9 +57,16 @@ void HandEyeCalibrationDisplay::save(rviz::Config config) const
 // Load all configuration data for this panel from the given Config object.
 void HandEyeCalibrationDisplay::load(const rviz::Config& config)
 {
-  frame_->load(config);
+  frame_->loadWidget(config);
 
   ROS_INFO_STREAM("handeye calibration gui loaded.");
 }
 
+void HandEyeCalibrationDisplay::update(float wall_dt, float ros_dt)
+{
+}
+
+void HandEyeCalibrationDisplay::reset()
+{
+}
 }  // namespace moveit_rviz_plugin

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -58,7 +58,6 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
                                  "The topic on which the moveit_msgs::PlanningScene messages are received", this,
                                  SLOT(changedPlanningSceneTopic()), this);
 
-  /* TODO: move parameters here instead of in context tab
   fov_marker_enabled_property_ = new rviz::BoolProperty(
       "Camera FOV Marker", true, "Enable marker showing camera field of view", this, SLOT(changedFOVEnabled()), this);
   fov_marker_alpha_property_ =
@@ -67,7 +66,6 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
   fov_marker_size_property_ =
       new rviz::FloatProperty("Marker Size", 1.f, "Specifies the size (depth in meters) for the rendered marker",
                               fov_marker_enabled_property_, SLOT(changedFOVSize()), this);
-                              */
 }
 
 void HandEyeCalibrationDisplay::onInitialize()

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -81,7 +81,6 @@ void HandEyeCalibrationDisplay::onInitialize()
   {
     frame_dock_ = window_context->addPane("HandEye Calibration", frame_);
   }
-  setStatus(rviz::StatusProperty::Ok, "Hello", "world");
 }
 
 HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay() = default;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -64,7 +64,7 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
       new rviz::FloatProperty("Marker Alpha", 0.3f, "Specifies the alpha (transparency) for the rendered marker",
                               fov_marker_enabled_property_, SLOT(changedFOVAlpha()), this);
   fov_marker_size_property_ =
-      new rviz::FloatProperty("Marker Size", 1.f, "Specifies the size (depth in meters) for the rendered marker",
+      new rviz::FloatProperty("Marker Size", 1.5f, "Specifies the size (depth in meters) for the rendered marker",
                               fov_marker_enabled_property_, SLOT(changedFOVSize()), this);
 }
 
@@ -114,43 +114,42 @@ void HandEyeCalibrationDisplay::reset()
 
 void HandEyeCalibrationDisplay::changedMoveGroupNS()
 {
-  // TODO
+  if (frame_ && frame_->tab_control_)
+  {
+    frame_->tab_control_->fillPlanningGroupNameComboBox();
+  }
 }
 
 void HandEyeCalibrationDisplay::changedPlanningSceneTopic()
 {
-  // TODO
-  /*
-  if (planning_scene_monitor_ && planning_scene_topic_property_)
+  if (frame_ && frame_->tab_control_)
   {
-    planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
-    std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
-    if (!getMoveGroupNS().empty())
-      service_name = ros::names::append(getMoveGroupNS(), service_name);
-    auto bg_func = [=]() {
-      if (planning_scene_monitor_->requestPlanningSceneState(service_name))
-        addMainLoopJob(boost::bind(&PlanningSceneDisplay::onNewPlanningSceneState, this));
-      else
-        setStatus(rviz::StatusProperty::Warn, "PlanningScene", "Requesting initial scene failed");
-    };
-    addBackgroundJob(bg_func, "requestPlanningSceneState");
+    frame_->tab_control_->fillPlanningGroupNameComboBox();
   }
-  */
 }
 
 void HandEyeCalibrationDisplay::changedFOVEnabled()
 {
-  // TODO
+  if (frame_ && frame_->tab_context_)
+  {
+    frame_->tab_context_->updateAllMarkers();
+  }
 }
 
 void HandEyeCalibrationDisplay::changedFOVAlpha()
 {
-  // TODO
+  if (frame_ && frame_->tab_context_)
+  {
+    frame_->tab_context_->updateAllMarkers();
+  }
 }
 
 void HandEyeCalibrationDisplay::changedFOVSize()
 {
-  // TODO
+  if (frame_ && frame_->tab_context_)
+  {
+    frame_->tab_context_->updateAllMarkers();
+  }
 }
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -58,6 +58,7 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
                                  "The topic on which the moveit_msgs::PlanningScene messages are received", this,
                                  SLOT(changedPlanningSceneTopic()), this);
 
+  /* TODO: move parameters here instead of in context tab
   fov_marker_enabled_property_ = new rviz::BoolProperty(
       "Camera FOV Marker", true, "Enable marker showing camera field of view", this, SLOT(changedFOVEnabled()), this);
   fov_marker_alpha_property_ =
@@ -66,6 +67,7 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
   fov_marker_size_property_ =
       new rviz::FloatProperty("Marker Size", 1.f, "Specifies the size (depth in meters) for the rendered marker",
                               fov_marker_enabled_property_, SLOT(changedFOVSize()), this);
+                              */
 }
 
 void HandEyeCalibrationDisplay::onInitialize()

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -68,6 +68,12 @@ HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display(
                               fov_marker_enabled_property_, SLOT(changedFOVSize()), this);
 }
 
+HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay()
+{
+  if (frame_dock_)
+    delete frame_dock_;
+}
+
 void HandEyeCalibrationDisplay::onInitialize()
 {
   Display::onInitialize();
@@ -80,8 +86,6 @@ void HandEyeCalibrationDisplay::onInitialize()
     frame_dock_ = window_context->addPane("HandEye Calibration", frame_);
   }
 }
-
-HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay() = default;
 
 void HandEyeCalibrationDisplay::save(rviz::Config config) const
 {

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -37,14 +37,30 @@
 #include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
 #include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h>
 
+#include <rviz/window_manager_interface.h>
+
 #include <Eigen/Geometry>
 #include <cmath>
 
+#include <iostream>
+
 namespace moveit_rviz_plugin
 {
-HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : rviz::Display()
+HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : Display()
 {
-  frame_ = new HandEyeCalibrationFrame();
+}
+
+void HandEyeCalibrationDisplay::onInitialize()
+{
+  Display::onInitialize();
+
+  rviz::WindowManagerInterface* window_context = context_->getWindowManager();
+  frame_ = new HandEyeCalibrationFrame(context_, window_context ? window_context->getParentWindow() : nullptr);
+
+  if (window_context)
+  {
+    frame_dock_ = window_context->addPane("HandEye Calibration", frame_);
+  }
 }
 
 HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay() = default;

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h>
+
+#include <Eigen/Geometry>
+#include <cmath>
+
+namespace moveit_rviz_plugin
+{
+HandEyeCalibrationDisplay::HandEyeCalibrationDisplay(QWidget* parent) : rviz::Display()
+{
+  frame_ = new HandEyeCalibrationFrame::HandEyeCalibrationFrame();
+}
+
+HandEyeCalibrationDisplay::~HandEyeCalibrationDisplay() = default;
+
+void HandEyeCalibrationDisplay::save(rviz::Config config) const
+{
+  frame_->saveWidget(config);
+}
+
+// Load all configuration data for this panel from the given Config object.
+void HandEyeCalibrationDisplay::load(const rviz::Config& config)
+{
+  frame_->load(config);
+
+  ROS_INFO_STREAM("handeye calibration gui loaded.");
+}
+
+}  // namespace moveit_rviz_plugin

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_display.cpp
@@ -75,7 +75,7 @@ void HandEyeCalibrationDisplay::onInitialize()
   Display::onInitialize();
 
   rviz::WindowManagerInterface* window_context = context_->getWindowManager();
-  frame_ = new HandEyeCalibrationFrame(context_, window_context ? window_context->getParentWindow() : nullptr);
+  frame_ = new HandEyeCalibrationFrame(this, context_, window_context ? window_context->getParentWindow() : nullptr);
 
   if (window_context)
   {

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
@@ -34,14 +34,15 @@
 
 /* Author: Yu Yan */
 
-#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_frame.h>
 
 #include <Eigen/Geometry>
 #include <cmath>
 
 namespace moveit_rviz_plugin
 {
-HandEyeCalibrationGui::HandEyeCalibrationGui(QWidget* parent) : rviz::Panel(parent)
+HandEyeCalibrationFrame::HandEyeCalibrationFrame(QWidget* parent) : QWidget(parent)
 {
   setMinimumSize(695, 460);
   // Basic widget container
@@ -85,9 +86,9 @@ HandEyeCalibrationGui::HandEyeCalibrationGui(QWidget* parent) : rviz::Panel(pare
   ROS_INFO_STREAM("handeye calibration gui created.");
 }
 
-HandEyeCalibrationGui::~HandEyeCalibrationGui() = default;
+HandEyeCalibrationFrame::~HandEyeCalibrationFrame() = default;
 
-void HandEyeCalibrationGui::save(rviz::Config config) const
+void HandEyeCalibrationFrame::save(rviz::Config config) const
 {
   tab_target_->saveWidget(config);
   tab_context_->saveWidget(config);
@@ -96,7 +97,7 @@ void HandEyeCalibrationGui::save(rviz::Config config) const
 }
 
 // Load all configuration data for this panel from the given Config object.
-void HandEyeCalibrationGui::load(const rviz::Config& config)
+void HandEyeCalibrationFrame::load(const rviz::Config& config)
 {
   rviz::Panel::load(config);
 

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
@@ -88,19 +88,16 @@ HandEyeCalibrationFrame::HandEyeCalibrationFrame(QWidget* parent) : QWidget(pare
 
 HandEyeCalibrationFrame::~HandEyeCalibrationFrame() = default;
 
-void HandEyeCalibrationFrame::save(rviz::Config config) const
+void HandEyeCalibrationFrame::saveWidget(rviz::Config config) const
 {
   tab_target_->saveWidget(config);
   tab_context_->saveWidget(config);
   tab_control_->saveWidget(config);
-  rviz::Panel::save(config);
 }
 
 // Load all configuration data for this panel from the given Config object.
-void HandEyeCalibrationFrame::load(const rviz::Config& config)
+void HandEyeCalibrationFrame::loadWidget(const rviz::Config& config)
 {
-  rviz::Panel::load(config);
-
   tab_target_->loadWidget(config);
   tab_context_->loadWidget(config);
   tab_control_->loadWidget(config);

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
@@ -42,7 +42,8 @@
 
 namespace moveit_rviz_plugin
 {
-HandEyeCalibrationFrame::HandEyeCalibrationFrame(QWidget* parent) : QWidget(parent)
+HandEyeCalibrationFrame::HandEyeCalibrationFrame(rviz::DisplayContext* context, QWidget* parent)
+  : QWidget(parent), context_(context)
 {
   setMinimumSize(695, 460);
   // Basic widget container

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_calibration_frame.cpp
@@ -42,8 +42,9 @@
 
 namespace moveit_rviz_plugin
 {
-HandEyeCalibrationFrame::HandEyeCalibrationFrame(rviz::DisplayContext* context, QWidget* parent)
-  : QWidget(parent), context_(context)
+HandEyeCalibrationFrame::HandEyeCalibrationFrame(HandEyeCalibrationDisplay* pdisplay, rviz::DisplayContext* context,
+                                                 QWidget* parent)
+  : QWidget(parent), calibration_display_(pdisplay), context_(context)
 {
   setMinimumSize(695, 460);
   // Basic widget container
@@ -59,18 +60,18 @@ HandEyeCalibrationFrame::HandEyeCalibrationFrame(rviz::DisplayContext* context, 
 
   // Tab menu ------------------------------------------------------------
   QTabWidget* tabs = new QTabWidget(this);
-  tab_target_ = new TargetTabWidget();
+  tab_target_ = new TargetTabWidget(calibration_display_);
 
   tf_tools_.reset(new rviz_visual_tools::TFVisualTools(250));
 
-  tab_context_ = new ContextTabWidget();
+  tab_context_ = new ContextTabWidget(calibration_display_);
   tab_context_->setTFTool(tf_tools_);
   connect(tab_target_, SIGNAL(cameraInfoChanged(sensor_msgs::CameraInfo)), tab_context_,
           SLOT(setCameraInfo(sensor_msgs::CameraInfo)));
   connect(tab_target_, SIGNAL(opticalFrameChanged(const std::string&)), tab_context_,
           SLOT(setOpticalFrame(const std::string&)));
 
-  tab_control_ = new ControlTabWidget();
+  tab_control_ = new ControlTabWidget(calibration_display_);
   tab_control_->setTFTool(tf_tools_);
   tab_control_->UpdateSensorMountType(0);
   connect(tab_context_, SIGNAL(sensorMountTypeChanged(int)), tab_control_, SLOT(UpdateSensorMountType(int)));

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
@@ -197,6 +197,7 @@ ContextTabWidget::ContextTabWidget(QWidget* parent) : QWidget(parent), tf_listen
   for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
     connect(frame.second, SIGNAL(activated(int)), this, SLOT(updateFrameName(int)));
 
+  // TODO: move this to display properties
   // FOV area
   QGroupBox* fov_group = new QGroupBox("FOV", this);
   layout_left->addWidget(fov_group);

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
@@ -154,7 +154,8 @@ void SliderWidget::changeSlider()
   Q_EMIT valueChanged(value);
 }
 
-ContextTabWidget::ContextTabWidget(QWidget* parent) : QWidget(parent), tf_listener_(tf_buffer_)
+ContextTabWidget::ContextTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* parent)
+  : QWidget(parent), calibration_display_(pdisplay), tf_listener_(tf_buffer_)
 {
   // Context setting tab ----------------------------------------------------
   QHBoxLayout* layout = new QHBoxLayout();

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
@@ -258,6 +258,9 @@ ContextTabWidget::ContextTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget*
   visual_tools_->setAlpha(1.0);
   visual_tools_->setLifetime(0.0);
   visual_tools_->trigger();
+
+  calibration_display_->setStatus(rviz::StatusProperty::Warn, "Calibration context",
+                                  "Not all calibration frames have been selected.");
 }
 
 void ContextTabWidget::loadWidget(const rviz::Config& config)
@@ -536,8 +539,22 @@ void ContextTabWidget::updateFrameName(int index)
   updateFOVPose();
 
   std::map<std::string, std::string> names;
+  bool any_empty = false;
   for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
+  {
     names.insert(std::make_pair(frame.first, frame.second->currentText().toStdString()));
+    any_empty = any_empty || frame.second->currentText().toStdString().empty();
+  }
+  if (any_empty)
+  {
+    calibration_display_->setStatus(rviz::StatusProperty::Warn, "Calibration context",
+                                    "Not all calibration frames have been selected.");
+  }
+  else
+  {
+    calibration_display_->setStatus(rviz::StatusProperty::Ok, "Calibration context",
+                                    "Calibration frames have been selected.");
+  }
 
   Q_EMIT frameNameChanged(names);
 }

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
@@ -345,9 +345,10 @@ void ContextTabWidget::updateAllMarkers()
         tf_tools_->publishTransform(camera_pose_, from_frame.toStdString(), to_frame.toStdString());
 
         // Publish new FOV marker
-        shape_msgs::Mesh mesh = getCameraFOVMesh(*camera_info_, 1.5);
         if (calibration_display_->fov_marker_enabled_property_->getBool())
         {
+          shape_msgs::Mesh mesh =
+              getCameraFOVMesh(*camera_info_, calibration_display_->fov_marker_size_property_->getFloat());
           visual_tools_->setBaseFrame(to_frame.toStdString());
           visual_tools_->setAlpha(calibration_display_->fov_marker_alpha_property_->getFloat());
           visual_tools_->publishMesh(fov_pose_, mesh, rvt::YELLOW, 1.0, "fov", 1);

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -230,6 +230,7 @@ ControlTabWidget::ControlTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget*
   if (loadSolverPlugin(plugins))
     fillSolverTypes(plugins);
 
+  // Connect PSM and get group names
   fillPlanningGroupNameComboBox();
 
   // Set plan and execution watcher

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -687,6 +687,8 @@ void ControlTabWidget::fillPlanningGroupNameComboBox()
   {
     planning_scene_monitor_->startSceneMonitor(calibration_display_->planning_scene_topic_property_->getStdString());
     std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
+    if (!calibration_display_->move_group_ns_property_->getStdString().empty())
+      service_name = ros::names::append(calibration_display_->move_group_ns_property_->getStdString(), service_name);
     if (planning_scene_monitor_->requestPlanningSceneState(service_name))
     {
       const robot_model::RobotModelConstPtr& kmodel = planning_scene_monitor_->getRobotModel();

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -95,8 +95,9 @@ int ProgressBarWidget::getValue()
   return bar_->value();
 }
 
-ControlTabWidget::ControlTabWidget(QWidget* parent)
+ControlTabWidget::ControlTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* parent)
   : QWidget(parent)
+  , calibration_display_(pdisplay)
   , tf_buffer_(new tf2_ros::Buffer())
   , tf_listener_(*tf_buffer_)
   , sensor_mount_type_(mhc::EYE_TO_HAND)

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
@@ -84,8 +84,9 @@ void RosTopicComboBox::mousePressEvent(QMouseEvent* event)
   showPopup();
 }
 
-TargetTabWidget::TargetTabWidget(QWidget* parent)
+TargetTabWidget::TargetTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* parent)
   : QWidget(parent)
+  , calibration_display_(pdisplay)
   , nh_("~")
   , it_(nh_)
   , target_plugins_loader_(nullptr)

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
@@ -423,7 +423,7 @@ void TargetTabWidget::imageCallback(const sensor_msgs::ImageConstPtr& msg)
 
       geometry_msgs::TransformStamped tf2_msg = target_->getTransformStamped(optical_frame_);
       tf_pub_.sendTransform(tf2_msg);
-      if (!target_->areIntrinsicsSane())
+      if (!target_->areIntrinsicsReasonable())
       {
         calibration_display_->setStatus(
             rviz::StatusProperty::Warn, "Target detection",

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
@@ -155,6 +155,9 @@ TargetTabWidget::TargetTabWidget(HandEyeCalibrationDisplay* pdisplay, QWidget* p
   // Register custom types
   qRegisterMetaType<sensor_msgs::CameraInfo>();
   qRegisterMetaType<std::string>();
+
+  // Initialize status
+  calibration_display_->setStatusStd(rviz::StatusProperty::Warn, "Target detection", "Not subscribed to image topic.");
 }
 
 void TargetTabWidget::loadWidget(const rviz::Config& config)
@@ -378,7 +381,11 @@ void TargetTabWidget::imageCallback(const sensor_msgs::ImageConstPtr& msg)
 
   // Depth image format `16UC1` cannot be converted to `MONO8`
   if (msg->encoding == "16UC1")
+  {
+    calibration_display_->setStatus(rviz::StatusProperty::Error, "Target detection",
+                                    "Received 16-bit image, which cannot be processed.");
     return;
+  }
 
   std::string frame_id = msg->header.frame_id;
   if (!frame_id.empty())
@@ -392,12 +399,15 @@ void TargetTabWidget::imageCallback(const sensor_msgs::ImageConstPtr& msg)
   else
   {
     ROS_ERROR_STREAM_NAMED(LOGNAME, "Image msg has empty frame_id.");
+    calibration_display_->setStatus(rviz::StatusProperty::Error, "Target detection",
+                                    "Image message has empty frame ID.");
     return;
   }
 
   if (msg->data.empty())
   {
     ROS_ERROR_STREAM_NAMED(LOGNAME, "Image msg has empty data.");
+    calibration_display_->setStatus(rviz::StatusProperty::Error, "Target detection", "Image message is empty.");
     return;
   }
 
@@ -413,20 +423,35 @@ void TargetTabWidget::imageCallback(const sensor_msgs::ImageConstPtr& msg)
 
       geometry_msgs::TransformStamped tf2_msg = target_->getTransformStamped(optical_frame_);
       tf_pub_.sendTransform(tf2_msg);
+      if (!target_->areIntrinsicsSane())
+      {
+        calibration_display_->setStatus(
+            rviz::StatusProperty::Warn, "Target detection",
+            "Target detector has not received reasonable intrinsics. Attempted detection anyway.");
+      }
+      else
+      {
+        calibration_display_->setStatus(rviz::StatusProperty::Ok, "Target detection", "Target pose detected.");
+      }
     }
     else
     {
       pub_msg = cv_bridge::CvImage(std_msgs::Header(), "mono8", cv_ptr->image).toImageMsg();
+      calibration_display_->setStatus(rviz::StatusProperty::Error, "Target detection", "Target detection failed.");
     }
     image_pub_.publish(pub_msg);
   }
   catch (cv_bridge::Exception& e)
   {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "cv_bridge exception: " << e.what());
+    std::string error_message = "cv_bridge exception: " + std::string(e.what());
+    calibration_display_->setStatusStd(rviz::StatusProperty::Error, "Target detection", error_message);
+    ROS_ERROR_NAMED(LOGNAME, "%s", error_message.c_str());
   }
   catch (cv::Exception& e)
   {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "cv exception: " << e.what());
+    std::string error_message = "cv exception: " + std::string(e.what());
+    calibration_display_->setStatusStd(rviz::StatusProperty::Error, "Target detection", error_message);
+    ROS_ERROR_NAMED(LOGNAME, "%s", error_message.c_str());
   }
 }
 
@@ -509,6 +534,8 @@ void TargetTabWidget::saveTargetImageBtnClicked(bool clicked)
 void TargetTabWidget::imageTopicComboboxChanged(const QString& topic)
 {
   image_sub_.shutdown();
+
+  calibration_display_->setStatusStd(rviz::StatusProperty::Warn, "Target detection", "Not subscribed to image topic.");
   if (!topic.isNull() and !topic.isEmpty())
   {
     try
@@ -518,6 +545,8 @@ void TargetTabWidget::imageTopicComboboxChanged(const QString& topic)
     catch (image_transport::TransportLoadException& e)
     {
       ROS_ERROR_STREAM_NAMED(LOGNAME, "Subscribe to image topic: " << topic.toStdString() << " failed. " << e.what());
+      calibration_display_->setStatusStd(rviz::StatusProperty::Error, "Target detection",
+                                         "Failed to subscribe to image topic.");
     }
   }
 }
@@ -525,6 +554,8 @@ void TargetTabWidget::imageTopicComboboxChanged(const QString& topic)
 void TargetTabWidget::cameraInfoComboBoxChanged(const QString& topic)
 {
   camerainfo_sub_.shutdown();
+  calibration_display_->setStatusStd(rviz::StatusProperty::Warn, "Target detection",
+                                     "Not subscribed to camera info topic.");
   if (!topic.isNull() and !topic.isEmpty())
   {
     try
@@ -535,6 +566,8 @@ void TargetTabWidget::cameraInfoComboBoxChanged(const QString& topic)
     {
       ROS_ERROR_STREAM_NAMED(LOGNAME,
                              "Subscribe to camera info topic: " << topic.toStdString() << " failed. " << e.what());
+      calibration_display_->setStatusStd(rviz::StatusProperty::Error, "Target detection",
+                                         "Failed to subscribe to camera info topic.");
     }
   }
 }

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/plugin_init.cpp
@@ -35,6 +35,6 @@
 /* Author: Yu Yan */
 
 #include <class_loader/class_loader.hpp>
-#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::HandEyeCalibrationGui, rviz::Panel)
+CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::HandEyeCalibrationDisplay, rviz::Display)

--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin_description.xml
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin_description.xml
@@ -1,7 +1,7 @@
 <library path="libmoveit_handeye_calibration_rviz_plugin">
-  <class name="moveit_rviz_plugin/HandEyeCalibration" type="moveit_rviz_plugin::HandEyeCalibrationGui" base_class_type="rviz::Panel">
+  <class name="moveit_rviz_plugin/HandEyeCalibration" type="moveit_rviz_plugin::HandEyeCalibrationDisplay" base_class_type="rviz::Display">
     <description>
-      Gui widget for the hand-eye calibration.
+      RViz display for the hand-eye calibration.
     </description>
   </class>
 </library>

--- a/moveit_calibration_plugins/handeye_calibration_target/include/moveit/handeye_calibration_target/handeye_target_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_target/include/moveit/handeye_calibration_target/handeye_target_base.h
@@ -254,6 +254,15 @@ public:
   }
 
   /**
+   * @brief Check that camera intrinsic parameters are sane.
+   * @return True if intrinsics are reasonable (camera matrix is not all zeros and is not the identity).
+   */
+  virtual bool areIntrinsicsSane()
+  {
+    return cv::norm(camera_matrix_) != 0. && cv::norm(camera_matrix_, cv::Mat::eye(3, 3, CV_64F)) != 0.;
+  }
+
+  /**
    * @brief Get parameters relevant to this target.
    * @return List of parameter objects
    */

--- a/moveit_calibration_plugins/handeye_calibration_target/include/moveit/handeye_calibration_target/handeye_target_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_target/include/moveit/handeye_calibration_target/handeye_target_base.h
@@ -254,10 +254,10 @@ public:
   }
 
   /**
-   * @brief Check that camera intrinsic parameters are sane.
+   * @brief Check that camera intrinsic parameters are reasonable.
    * @return True if intrinsics are reasonable (camera matrix is not all zeros and is not the identity).
    */
-  virtual bool areIntrinsicsSane()
+  virtual bool areIntrinsicsReasonable()
   {
     return cv::norm(camera_matrix_) != 0. && cv::norm(camera_matrix_, cv::Mat::eye(3, 3, CV_64F)) != 0.;
   }


### PR DESCRIPTION
Convert the RViz plugin from an rviz::Panel object to an rviz::Display. This allows parameter input and status feedback in the "Displays" panel.

While I was at it, I added parameters for the move_group namespace and PSM topic (borrowed from the PlanningScene display plugin), as well as some status messages for various components.

![moveit_cal_display](https://user-images.githubusercontent.com/519268/122860784-95555380-d2db-11eb-917d-2a165800086c.png)
