### PR TITLE
Fix swapped translation/rotation unit labels in reprojection error display

### DIFF
--- a/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_calibration_gui/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -409,7 +409,7 @@ bool ControlTabWidget::solveCameraRobotPose()
       const auto& reproj_err = solver_->getReprojectionError(effector_wrt_world_, object_wrt_sensor_,
                                                              camera_robot_pose_, sensor_mount_type_);
       std::ostringstream reproj_err_text;
-      reproj_err_text << "Reprojection error:\n" << reproj_err.first << " m, " << reproj_err.second << " rad";
+      reproj_err_text << "Reprojection error:\n" << reproj_err.first << " rad, " << reproj_err.second << " m";
       ROS_WARN_NAMED(LOGNAME, "%s", reproj_err_text.str().c_str());
       reprojection_error_label_->setText(QString(reproj_err_text.str().c_str()));
 

--- a/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
+++ b/moveit_calibration_plugins/handeye_calibration_solver/include/moveit/handeye_calibration_solver/handeye_solver_base.h
@@ -92,7 +92,7 @@ public:
    * with respect to the camera.
    * @param X The calibration, as a 4X4 transform.
    * @param setup Camera mount type, {EYE_TO_HAND, EYE_IN_HAND}.
-   * @return Pair of translation and rotation reprojection error in meters and radians, or NaNs on error.
+   * @return Pair of rotation and translation reprojection error in radians and meters, or NaNs on error.
    */
   std::pair<double, double> getReprojectionError(const std::vector<Eigen::Isometry3d>& effector_wrt_world,
                                                  const std::vector<Eigen::Isometry3d>& object_wrt_sensor,


### PR DESCRIPTION
## Problem

`ControlTabWidget::solveCameraRobotPose()` prints the reprojection error pair with the unit labels reversed.

`getReprojectionError()` (handeye_solver_base.h) returns:

```cpp
ret = std::make_pair(std::sqrt(rotation_err / num_motions),     // first  = rotation [rad]
                     std::sqrt(translation_err / num_motions));  // second = translation [m]
```

i.e. **rotation (radians) first, translation (meters) second**.

But the display (handeye_control_widget.cpp) labeled them the other way:

```cpp
reproj_err_text << "Reprojection error:\n" << reproj_err.first << " m, " << reproj_err.second << " rad";
```

So a user reading `X m, Y rad` actually sees `X = rotation (rad)` and `Y = translation (m)` — the units are swapped.

## Fix

- Swap the labels to match the returned order: `first` → ` rad`, `second` → ` m`.
- Correct the `getReprojectionError` docstring, which also described the pair in the opposite order ("translation and rotation in meters and radians").

The computed calibration is unaffected; this is a display/labeling fix only.